### PR TITLE
limit number of events created

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,17 +5,18 @@ class Event < ApplicationRecord
   enum status: { pending: 0, confirmed: 1, completed: 2 }
 
   def self.load(user)
-    Favorite.for_favoritor(user).each do |favorite|
+    Favorite.for_favoritor(user).sample(user.event_frequency).each do |favorite|
+      event = Event.new
       inspo = Inspo.find(favorite.favoritable_id)
       if inspo.genre = 'text'
         date = Time.new(Date.today.year, Date.today.month, Date.today.day, rand(8..20), [15, 30, 45, 0].sample)
+        event.content = inspo.content
       elsif inspo.genre = 'gift'
         date = Time.new(Date.today.year, Date.today.month, Date.today.day, rand(8..20))
       else
         date = Time.new(Date.today.year, Date.today.month, Date.today.day, rand(17..19))
       end
-      content = inspo.content if inspo.genre == 'text'
-      event = Event.new(date: date + 86400 * rand(1..14))
+      event.date = date + 86400 * rand(1..14)
       event.partner = user.partner
       event.inspo = inspo
       event.save!


### PR DESCRIPTION
This will still duplicate events. i can make it not do that (select for inspo_id = Inspo.find(favorite.favoritable_id in Event and count for 0) but I don't know how you want to revisit the inspo 'swipe'