### PR TITLE
back button on inspos goes to keywords

### DIFF
--- a/app/views/inspos/index.html.erb
+++ b/app/views/inspos/index.html.erb
@@ -10,7 +10,7 @@
   </div>
   <% if current_user.all_favorites.count == 0 %>
     <div class="back-skip">
-      <%= link_to ('<i class="fa-solid fa-circle-arrow-left"></i> Back').html_safe, new_partner_path, class: "dark-link" %>
+      <%= link_to ('<i class="fa-solid fa-circle-arrow-left"></i> Back').html_safe, partner_keywords_path(@current_user.partner), class: "dark-link" %>
       <%= link_to ('Skip <i class="fa-solid fa-circle-arrow-right"></i>').html_safe, events_loading_path, class: "dark-link" %>
     </div>
   <% end %>


### PR DESCRIPTION
In this PR -- the inspo back button goes to the keywords 
still need to fix keyword logic to edit. 