### PR TITLE
Completed events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -54,7 +54,6 @@ class EventsController < ApplicationController
   def update_success
     @event.success = !@event.success
     @event.save
-    p "the params are: #{params}"
 
     respond_to do |format|
       format.html
@@ -63,8 +62,10 @@ class EventsController < ApplicationController
   end
 
   def completed_events
-   @events = Event.where(partner_id: current_user.partner).where(status: :completed)
-   @events = @events.sort_by(&:date).reverse
+    @completed_events = Event.where(partner_id: current_user.partner).select { |event| event.date && DateTime.now.in_time_zone('Eastern Time (US & Canada)') > event.date }
+    @completed_events.each(&:completed!)
+
+    @completed_events = @completed_events.sort_by(&:date).reverse
   end
 
   def loading

--- a/app/views/events/completed_events.html.erb
+++ b/app/views/events/completed_events.html.erb
@@ -19,14 +19,14 @@
         </div>
       <% end %>
     </div>
-    <ul class="events-list" data-controller="edit-event">
-      <% @events.each do |event| %>
+    <div class="events-list" data-controller="edit-event">
+      <% @completed_events.each do |event| %>
         <h6 class="mb-2"><%= event.date.in_time_zone('Eastern Time (US & Canada)').strftime("%A, %b %e") %></h6>
         <div>
           <%= render "shared/event-card-completed", event: event %>
           <%= render "shared/show-event-card", event: event %>
         </div>
       <% end %>
-    </ul>
+    </div>
   </div>
 </div>

--- a/app/views/events/completed_events.html.erb
+++ b/app/views/events/completed_events.html.erb
@@ -6,16 +6,16 @@
 <div class="banner-margin">
   <div class="wrapper">
     <div class="dashboard-info">
-      <% if current_user.partner == nil %>
+      <% if current_user.partner.nil? %>
         <div class="center-dashboard">
           <h2>You don't have <br> a partner yet.</h2>
           <%= link_to "Create a partner profile", new_partner_path, class: "btn-flat mt-3" %>
         </div>
-      <% elsif current_user.partner && current_user.partner.events.where(status: :completed).count == 0 %>
+      <% elsif current_user.partner.events.where(status: :completed).count.zero? %>
         <div class="center-dashboard">
           <h2 class="mb-3">You have no <br> past events.</h2>
-          <%= link_to 'Generate events', events_loading_path, class:"btn btn-flat"%>
           <%= link_to 'Create new event', new_event_path, class:"btn btn-flat mt-3" %>
+          <%= link_to 'Generate new events', partner_keywords_path(current_user.partner), class:"btn btn-flat mt-3"%>
         </div>
       <% end %>
     </div>

--- a/app/views/shared/_edit-event-card.html.erb
+++ b/app/views/shared/_edit-event-card.html.erb
@@ -49,7 +49,7 @@
     <% end %>
     <%= simple_form_for event do |f| %>
       <%= f.input :date, html5: true, label: "Event Date:" %>
-      <%= f.hidden_field :status, :value => Event.statuses.key(1) %>
+      <%= f.hidden_field :status, value: Event.statuses.key(1) %>
       <% if event.inspo.genre == "text" %>
         <%= f.input :content, label: "Message:", input_html: { value: event.inspo.content } %>
       <% end %>


### PR DESCRIPTION
controller did not mark events completed unless dashboard method first called
'generate new events' only displays loading page from completed events view - now fixed
pages when no partner and when no completed events now match similar pages on dashboard, etc.